### PR TITLE
Add "partial" to RequestInit definition

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -947,8 +947,7 @@ spec:websockets; type:dfn; for:/; text:establish a websocket connection
     <dfn export>targetAddressSpace</dfn>, and [=map/value=] is a
     {{RequestTargetAddressSpace}}.
       <pre class="idl">
-        dictionary RequestInit {
-          // ...
+        partial dictionary RequestInit {
           RequestTargetAddressSpace targetAddressSpace;
         };
       </pre>


### PR DESCRIPTION
The prose is clear that the IDL definition of `RequestInit` needs to be adjusted in Fetch to add `targetAddressSpace` and that the IDL should be read as a partial definition, but tools that process IDL in specs automatically (typically Reffy to create the Webref database) don't read prose and see two definitions of `RequestInit`, one in Fetch and on in Private Network Access.

This update adds the `partial` keyword to make it clear to spec IDL scrappers that Private Network Access extends the definition of `RequestInit`.