### PR TITLE
Fix AVASTIUM and TREND-MIRCO links

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -83,11 +83,11 @@ spec:websockets; type:dfn; for:/; text:establish a websocket connection
   },
 
   "AVASTIUM": {
-    "href": "https://code.google.com/p/google-security-research/issues/detail?id=679",
+    "href": "https://bugs.chromium.org/p/project-zero/issues/detail?id=679",
     "title": "Avast: A web-accessible RPC endpoint can launch 'SafeZone' (also called Avastium), a Chromium fork with critical security checks removed."
   },
   "TREND-MICRO": {
-    "href": "https://code.google.com/p/google-security-research/issues/detail?id=693",
+    "href": "https://bugs.chromium.org/p/project-zero/issues/detail?id=693",
     "title": "TrendMicro node.js HTTP server listening on localhost can execute commands"
   },
 


### PR DESCRIPTION
The old links showed  

> This project has moved to: project-zero.
> The issue does not exist.

without automatic or link-based redirects.
